### PR TITLE
Travis: Prevent to run HTTP tests with PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.6
   - 5.5
   - 5.4
-#  - 5.3 doesn't provide a 'php' webserver as required in tests/api/run.sh
+  - 5.3 # doesn't provide a 'php' webserver as required in tests/api/run.sh
 install:
   - composer self-update
   - composer install
@@ -13,8 +13,23 @@ addons:
   apt:
     packages:
     - xsltproc
+env:
+  - HTTPTEST=1
+  - HTTPTEST=0
+matrix:
+  exclude:
+    - php: 5.3
+      env: HTTPTEST=1
+    - php: 5.4
+      env: HTTPTEST=0
+    - php: 5.5
+      env: HTTPTEST=0
+    - php: 5.6
+      env: HTTPTEST=0
+    - php: 7.0
+      env: HTTPTEST=0
 script:
   - make clean
   - make check_permissions
   - make test
-  - sh tests/api/run.sh
+  - if [[ $HTTPTEST == 1 ]]; then sh tests/api/run.sh; fi

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ test:
 	@echo "PHPUNIT"
 	@echo "-------"
 	@mkdir -p sandbox
-	@$(BIN)/phpunit tests
+	@$(BIN)/phpunit --configuration phpunit.xml
 
 ##
 # Targets for repository and documentation maintenance

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
     colors="true">
+  <testsuites>
+    <testsuite name="unit-tests">
+      <directory>tests</directory>
+      <exclude>tests/api</exclude>
+    </testsuite>
+  </testsuites>
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">
       <directory suffix=".php">application</directory>


### PR DESCRIPTION
I've managed to run only unit tests with PHP 5.3. It's not very elegant, but it works, and I couldn't find a better way. I think we can merge your PR upstream with this.

@virtualtam: opinion on this?